### PR TITLE
Proposed draft-02 text based around designated resolvers

### DIFF
--- a/draft-add-requirements.md
+++ b/draft-add-requirements.md
@@ -287,8 +287,8 @@ This section lists requirements that flow from the above sections.
 | R2.2 | The format for resolver designation SHOULD be specified such that provisioning mechanisms defined outside of the IETF can advertise encrypted DNS resolvers. |
 | R2.3 | This format SHOULD convey, at minimum, the information the client needs to make contact with each designated resolver. |
 | R2.4 | This format MAY convey additional resolver information. |
-| R3.1 | When discovery is instantiated from a resolver (R1.2), that resolver MAY be encrypted or not. |
-| R3.2 | When discovery is instantiated from a resolver (R1.2), that resolver MAY be locally or globally reachable. Both options SHOULD be supported. |
+| R3.1 | In resolver-identified designation (R1.2), the communication with the designator MAY be encrypted or not, depending on the capability of the resolver. |
+| R3.2 | In resolver-identified designation (R1.2), that resolver MAY be locally or globally reachable. Both options SHOULD be supported. |
 | R4.1 | In a home network use case, if the local network resolver is a forwarder that does not offer encrypted DNS service, an upstream encrypted resolver SHOULD be retrievable via queries sent to that forwarder. |
 | R4.2 | Achieving requirement 4.1 SHOULD NOT require any changes to DNS forwarders hosted on non-upgradable legacy network devices. |
 | R5.1 | Discovery MUST NOT worsen a client's security or privacy posture. |

--- a/draft-add-requirements.md
+++ b/draft-add-requirements.md
@@ -144,7 +144,7 @@ is designated by the network it has joined.
 Designation is the process by which a local network or a resolver can point clients towards a particular set of encrypted resolvers.
 This set can be empty, or it can list the contact details (such as DoH URI Template) of encrypted DNS resolvers that it recommends.
 It is not required that there be any relationship between the resolvers in the set, simply that all of them are options that the
-designator asserts are safe and appropriate for the client to use.
+designator asserts are safe and appropriate for the client to use without user intervention.
 
 There are two possible sources of designation.
 
@@ -314,4 +314,3 @@ on the list, and with text from draft-pauly-add-requirements. In particular this
 from Martin Thomson, Eric Rescorla, Tommy Jensen, Ben Schwartz, Paul Hoffman, Ralf Weber, Michael Richardson,
 Mohamed Boucadair, Sanjay Mishra, Jim Reid, Neil Cook, Nic Leymann, Andrew Campling, Eric Orth, Ted Hardie,
 Paul Vixie, Vittorio Bertola, and Vinny Parla.
-

--- a/draft-add-requirements.md
+++ b/draft-add-requirements.md
@@ -286,7 +286,7 @@ This section lists requirements that flow from the above sections.
 | R2.1 | Networks SHOULD be able to announce one or more designated encrypted DNS resolvers using existing mechanisms such as DHCPv4, DHCPv6, IPv6 Router Advertisement, and the Point-to-Point Protocol. |
 | R2.2 | The format for resolver designation SHOULD be specified such that provisioning mechanisms defined outside of the IETF can advertise encrypted DNS resolvers. |
 | R2.3 | This format SHOULD convey, at minimum, the information the client needs to make contact with each designated resolver. |
-| R2.4 | This format MAY convey more information. |
+| R2.4 | This format MAY convey additional resolver information. |
 | R3.1 | When discovery is instantiated from a resolver (R1.2), that resolver MAY be encrypted or not. |
 | R3.2 | When discovery is instantiated from a resolver (R1.2), that resolver MAY be locally or globally reachable. Both options SHOULD be supported. |
 | R4.1 | In a home network use case, if the local network resolver is a forwarder that does not offer encrypted DNS service, an upstream encrypted resolver SHOULD be retrievable via queries sent to that forwarder. |

--- a/draft-add-requirements.md
+++ b/draft-add-requirements.md
@@ -284,7 +284,7 @@ This section lists requirements that flow from the above sections.
 | Requirement | Description |
 | R1.1 | Discovery SHOULD provide a local network the ability to announce to clients a set of, or absence of, designated resolvers. |
 | R1.2 | Discovery SHOULD provide a resolver the ability to announce to clients a set of, or absence of, designated resolvers. |
-| R1.3 | Discovery SHOULD support all standardised encrypted DNS protocols. |
+| R1.3 | Discovery SHOULD support all encrypted DNS protocols standardised by the IETF. |
 | R2.1 | Networks SHOULD be able to announce one or more designated encrypted DNS resolvers using existing mechanisms such as DHCPv4, DHCPv6, IPv6 Router Advertisement, and the Point-to-Point Protocol. |
 | R2.2 | The format for resolver designation SHOULD be specified such that provisioning mechanisms defined outside of the IETF can advertise encrypted DNS resolvers. |
 | R2.3 | This format SHOULD convey, at minimum, the information the client needs to make contact with each designated resolver. |

--- a/draft-add-requirements.md
+++ b/draft-add-requirements.md
@@ -83,7 +83,7 @@ provisioning of encrypted resolvers can expand the usefulness and applicability 
 
 The Adaptive DNS Discovery (ADD) Working Group is chartered to define mechanisms that allow clients to automatically
 discover and select encrypted DNS resolvers in a wide variety of network environments. This document describes one common
-use case, namely that of clients that connect to a network but where they cannot securely authenticate the identity of
+use case, namely that of clients that connect to a network but where they cannot securely authenticate
 that network. Whether the network required credentials before the client was permitted to join is irrelevant; the client
 still cannot be sure that it has connected to the network it was expecting.
 

--- a/draft-add-requirements.md
+++ b/draft-add-requirements.md
@@ -113,7 +113,7 @@ Designated: See {{designation}}.
 Designator: The network or resolver that issued the designation.
 
 
-# Overall use case
+# Use case description
 
 It is often the case that a client possesses no specific configuration for how to operate DNS, and at some point
 joins a network that it cannot authenticate. It may have no prior knowledge of the network, or it may have connected

--- a/draft-add-requirements.md
+++ b/draft-add-requirements.md
@@ -166,15 +166,18 @@ either at the same (local) address, or at a different global address. Both optio
 ## Use of designation information
 
 After the client receives designation information, it must come to a decision on whether and when to use any of the
-designated resolvers. To support this process, it would be advantageous for a solution to enable the client to validate
-the source of the assertion in some way. For example for both network-identified and resolver-identified designation, it
-may be possible to verify that the designation comes from an entity who already has full control of the client's Do53
-queries. It would be beneficial to extend this to defend against attackers that have only transient control of such queries.
+designated resolvers. 
+
+In the case of resolver-identified designation, it would be advantageous for a solution to enable the client to
+validate the source of the assertion in some way. For example it may be possible to verify that the designation
+comes from an entity who already has full control of the client's Do53 queries. Network-identified designation should
+not require this, unless the network-identified resolver in turn initiated a new resolver-identified designation.
+It would be beneficial to extend such a verification process to defend against attackers that have only transient
+control of such queries.
 
 Clients may also seek to validate the identity of the designated resolver, beyond what is required by the relevant
 protocol. Authors of solution specifications should be aware that clients may impose arbitrary additional
 requirements and heuristics as they see fit.
-
 
 ## Network-identified designated resolvers
 

--- a/draft-add-requirements.md
+++ b/draft-add-requirements.md
@@ -172,7 +172,8 @@ may be possible to verify that the designation comes from an entity who already 
 queries. It would be beneficial to extend this to defend against attackers that have only transient control of such queries.
 
 Clients may also seek to validate the identity of the designated resolver, beyond what is required by the relevant
-protocol. In general, clients may impose arbitrary additional requirements and heuristics as they see fit.
+protocol. Authors of solution specifications should be aware that clients may impose arbitrary additional
+requirements and heuristics as they see fit.
 
 
 ## Network-identified designated resolvers

--- a/draft-add-requirements.md
+++ b/draft-add-requirements.md
@@ -118,11 +118,11 @@ Designator: The network or resolver that issued the designation.
 It is often the case that a client possesses no specific configuration for how to operate DNS, and at some point
 joins a network that it cannot authenticate. It may have no prior knowledge of the network, or it may have connected
 previously to a network that looked the same. In either case the usual behaviour, because of lack of specific
-configuration, is to dynamically discover the network's recommended Do53 resolver and use it. This long-standing practice
+configuration, is to dynamically discover the network's designated Do53 resolver and use it. This long-standing practice
 works in nearly all networks, but presents a number of privacy and security risks that were the motivation for the
 development of encrypted DNS.
 
-The network's recommended Do53 resolver may have a number of properties that differ from a generic resolver.
+The network's designated Do53 resolver may have a number of properties that differ from a generic resolver.
 It may be able to answer names that are not known globally, it may exclude some names (for positive or negative
 reasons), and it may provide address answers that have improved proximity. In this use case it is assumed that
 the user who chose to join this network would also like to make use of these properties of the network's unencrypted resolver,
@@ -134,15 +134,20 @@ Using an encrypted and authenticated resolver can provide several benefits that 
 - Authenticate that the DNS resolver is the correct one
 - Verify that answers come from the selected DNS resolver
 
-To meet this case there should be a means by which the client can learn how to contact an encrypted DNS resolver that
-is designated by the network it has joined.
+To meet this case there should be a means by which the client can learn how to contact a set of encrypted DNS resolvers that
+are designated by the network it has joined.
 
 
 {: #designation}
 ## Designation 
 
-Designation is the process by which a local network or a resolver can point clients towards a particular set of encrypted resolvers.
-This set can be empty, or it can list the contact details (such as DoH URI Template) of encrypted DNS resolvers that it recommends.
+Designation is the process by which a local network or a resolver can point clients towards a particular set of resolvers.
+This is not a new concept, as networks have been able to dynamically designate Do53 resolvers for decades (see {{network}}).
+However here we extend the concept in two ways:
+* To allow resolvers to designate other resolvers
+* The inclusion of support for encrypted DNS
+
+The designated set could be empty, or it could list the contact details (such as DoH URI Template) of DNS resolvers that it recommends.
 It is not required that there be any relationship between the resolvers in the set, simply that all of them are options that the
 designator asserts are safe and appropriate for the client to use without user intervention.
 
@@ -179,6 +184,7 @@ Clients may also seek to validate the identity of the designated resolver, beyon
 protocol. Authors of solution specifications should be aware that clients may impose arbitrary additional
 requirements and heuristics as they see fit.
 
+{: #network}
 ## Network-identified designated resolvers
 
 DNS servers are often provisioned by a network as part of DHCP options {{?RFC2132}},
@@ -193,8 +199,8 @@ upstream, or on the public Internet.
 ## Resolver-identified designated resolvers
 
 To support cases where the network is unable to identify an encrypted resolver, it should be possible to learn
-the details of one or more designated encrypted DNS resolvers by communicating with the network-recommended
-unencrypted Do53 resolver. This should involve an exchange that uses standard DNS messages that can be
+the details of one or more designated encrypted DNS resolvers by communicating with the network's designated
+Do53 resolver. This should involve an exchange that uses standard DNS messages that can be
 handled, or forwarded, by existing deployed software.
 
 Each resolver in the set may be at a different network location, which leads to several subcases for the mapping from Do53
@@ -233,7 +239,7 @@ or reactively ("I don't know the answer to that, but your local Do53 should know
 
 ### Public to public
 
-In cases where the local network has recommended a Do53 resolver on the public Internet, this resolver may designate its
+In cases where the local network has designated a Do53 resolver on the public Internet, this resolver may designate its
 own or another public encrypted DNS service. Since public IP addresses may appear in TLS certificates, solutions may
 use this as one way to validate that the designated encrypted resolver is legitimately associated with the original Do53.
 

--- a/draft-add-requirements.md
+++ b/draft-add-requirements.md
@@ -289,7 +289,7 @@ This section lists requirements that flow from the above sections.
 | R2.4 | This format MAY convey additional resolver information. |
 | R3.1 | In resolver-identified designation (R1.2), the communication with the designator MAY be encrypted or not, depending on the capability of the resolver. |
 | R3.2 | In resolver-identified designation (R1.2), that resolver MAY be locally or globally reachable. Both options SHOULD be supported. |
-| R4.1 | In a home network use case, if the local network resolver is a forwarder that does not offer encrypted DNS service, an upstream encrypted resolver SHOULD be retrievable via queries sent to that forwarder. |
+| R4.1 | If the local network resolver is a forwarder that does not offer encrypted DNS service, an upstream encrypted resolver SHOULD be retrievable via queries sent to that forwarder. |
 | R4.2 | Achieving requirement 4.1 SHOULD NOT require any changes to DNS forwarders hosted on non-upgradable legacy network devices. |
 | R5.1 | Discovery MUST NOT worsen a client's security or privacy posture. |
 | R5.2 | Threat modelling MUST assume that there is a passive eavesdropping attacker on the local network. |

--- a/draft-add-requirements.md
+++ b/draft-add-requirements.md
@@ -207,7 +207,8 @@ of a local caching resolver with knowledge of the local topology.
 Clients will be aware when the designated resolver has the same IP address as the Do53 (after looking up its name if required). They
 can use this information in their decision-making as to the level of trust to place in the designated resolver.
 In some networks it will not be possible to deploy encrypted DNS on the same IP address, e.g. because of the increased
-resource requirements of encrypted DNS. Discovery solutions should work in the presence of a change of address.
+resource requirements of encrypted DNS. Discovery solutions should work in the presence of a change to a different
+local IP address.
 
 An additional benefit of using a local resolver occurs with IoT devices. A common usage pattern for such devices
 is for it to "call home" to a service that resides on the public Internet, where that service is referenced through a

--- a/draft-add-requirements.md
+++ b/draft-add-requirements.md
@@ -144,6 +144,7 @@ are designated by the network it has joined.
 Designation is the process by which a local network or a resolver can point clients towards a particular set of resolvers.
 This is not a new concept, as networks have been able to dynamically designate Do53 resolvers for decades (see {{network}}).
 However here we extend the concept in two ways:
+
 * To allow resolvers to designate other resolvers
 * The inclusion of support for encrypted DNS
 

--- a/draft-add-requirements.md
+++ b/draft-add-requirements.md
@@ -1,7 +1,7 @@
 ---
-title: "Requirements for Adaptive DNS Discovery"
+title: "Requirements for Discovering Designated Resolvers"
 abbrev: "ADDREQ"
-docname: draft-box-add-requirements-01
+docname: draft-box-add-requirements-02
 category: info
 
 ipr: trust200902
@@ -65,9 +65,10 @@ informative:
 --- abstract
 
 Adaptive DNS Discovery is chartered to define mechanisms that allow clients to discover and select encrypted DNS
-resolvers. This document describes one common use case, that of discovering the encrypted DNS resolver that
-corresponds to the Do53 resolver offered by a network. It lists requirements that any proposed discovery mechanisms
-should address.
+resolvers. This document describes one common use case, namely that of clients that connect to a network but where they
+cannot securely authenticate the identity of that network. In such cases the client would like to learn which
+encrypted DNS resolvers are designated by that network or by the Do53 resolver offered by that network.
+It lists requirements that any proposed discovery mechanisms should seek to address.
 
 --- middle
 
@@ -81,10 +82,13 @@ While it is possible for clients to statically configure encrypted DNS resolvers
 provisioning of encrypted resolvers can expand the usefulness and applicability of encrypted DNS to many more use cases.
 
 The Adaptive DNS Discovery (ADD) Working Group is chartered to define mechanisms that allow clients to automatically
-discover and select encrypted DNS resolvers in a wide variety of network environments.
-This document currently focusses on one common use case, that of discovering the encrypted DNS resolver that corresponds to
-the Do53 resolver offered by a network. Additional use cases can be added in future versions.
-As well as describing the use case, it lists requirements that any proposed discovery mechanisms should address.
+discover and select encrypted DNS resolvers in a wide variety of network environments. This document describes one common
+use case, namely that of clients that connect to a network but where they cannot securely authenticate the identity of
+that network. Whether the network required credentials before the client was permitted to join is irrelevant; the client
+still cannot be sure that it has connected to the network it was expecting.
+
+In such cases the client would like to learn which encrypted DNS resolvers are designated by that network, or by the Do53
+resolver offered by that network. It lists requirements that any proposed discovery mechanisms should seek to address.
 They can do this either by providing a solution, or by explicitly stating why it is not in scope.
 
 
@@ -104,61 +108,74 @@ the IETF may publish, such as DNS-over-QUIC {{?I-D.ietf-dprive-dnsoquic}}.
 
 Do53: Unencrypted DNS over UDP port 53, or TCP port 53 {{?RFC1035}}.
 
-Equivalent: See {{equivalence}}.
+Designated: See {{designation}}.
+
+Designator: The network or resolver that issued the designation.
 
 
-# Use case description
+# Overall use case
 
 It is often the case that a client possesses no specific configuration for how to operate DNS, and at some point
-joins a network that it has no previous knowledge about. In such a case the usual existing behaviour is to
-dynamically discover the network's recommended Do53 resolver and use it. This long-standing practice works in
-nearly all networks, but presents a number of privacy and security risks that were the motivation for the development
-of encrypted DNS.
+joins a network that it cannot authenticate. It may have no prior knowledge of the network, or it may have connected
+previously to a network that looked the same. In either case the usual behaviour, because of lack of specific
+configuration, is to dynamically discover the network's recommended Do53 resolver and use it. This long-standing practice
+works in nearly all networks, but presents a number of privacy and security risks that were the motivation for the
+development of encrypted DNS.
 
-The network's recommended unencrypted resolver may have a number of properties that differ from a generic resolver.
+The network's recommended Do53 resolver may have a number of properties that differ from a generic resolver.
 It may be able to answer names that are not known globally, it may exclude some names (for positive or negative
 reasons), and it may provide address answers that have improved proximity. In this use case it is assumed that
 the user who chose to join this network would also like to make use of these properties of the network's unencrypted resolver,
 at least some of the time. However they would like to use an encrypted DNS protocol rather than Do53.
 
-Using an encrypted and authenticated resolver that is equivalent to the one provisioned by the network
-can provide several benefits that are not possible if only unencrypted DNS is used:
+Using an encrypted and authenticated resolver can provide several benefits that are not possible if only unencrypted DNS is used:
 
 - Prevent other devices on the network from observing client DNS messages
 - Authenticate that the DNS resolver is the correct one
 - Verify that answers come from the selected DNS resolver
 
-To meet this case there should be a means by which the client can learn how to contact an encrypted DNS resolver
-that provides equivalent responses as the ones served by the network's recommended unencrypted resolver.
-It is not a requirement that these two resolvers are the same physical or logical machine. Often they will be, but they
-could equally be separated, perhaps by hundreds of miles. However it is deployed, the key is that they are equivalent.
+To meet this case there should be a means by which the client can learn how to contact an encrypted DNS resolver that
+is designated by the network it has joined.
 
-{: #equivalence}
-## Equivalence 
 
-Given two resolvers A and B, equivalence is the claim that A and B can provide the same upper-layer DNS function
-to the client. This does not include the DNS transport protocol (e.g. Do53 or DNS-over-HTTPS) which can differ between
-equivalent resolvers. To provide equivalence it is frequently likely to be the case that A and B are operated by the same
-administrative domain, but this document does not require that.
+{: #designation}
+## Designation 
 
-There are two possible ways to claim equivalence.
+Designation is the process by which a local network or a resolver can point clients towards a particular set of encrypted resolvers.
+This set can be empty, or it can list the contact details (such as DoH URI Template) of encrypted DNS resolvers that it recommends.
+It is not required that there be any relationship between the resolvers in the set, simply that all of them are options that the
+designator asserts are safe and appropriate for the client to use.
 
-* The local network can claim that one or more encrypted DNS resolvers (B, C, etc) are equivalent to the Do53 resolver (A) it has offered. This is known as network-identified.
-* During communication with the (often unencrypted) resolver (A), this resolver can claim that one or more encrypted DNS resolvers (B, C, etc) are equivalent. This is known as resolver-identified.
+There are two possible sources of designation.
 
-Network-identified is preferred since it comes from the same source of information, and removes the need to talk to the Do53 resolver
-at all. However it cannot be the sole mechanism, at least for several years, since there is a large installed base of local
-network equipment that is difficult to upgrade with new features. Hence the second mechanism must support being able to
-announce an equivalent resolver using only existing widely-deployed DNS features.
+* The local network can designate one or more encrypted DNS resolvers (B, C, etc) in addition to any Do53 resolver (A) it may offer. This is known as network-identified.
+* During communication with the (often unencrypted) resolver (A), this resolver can designate one or more encrypted DNS resolvers (B, C, etc). This is known as resolver-identified.
+
+Network-identified has the advantages that it derives from the same source of information as the network's Do53 announcement, and
+removes the need to talk to the Do53 resolver at all. However it cannot be the sole mechanism, at least for several years, since
+there is a large installed base of local network equipment that is difficult to upgrade with new features. Hence the second mechanism
+should support being able to designate resolvers using only existing widely-deployed DNS features.
 
 ## Local addressing
 
 Many networks offer a Do53 resolver on an address that is not globally meaningful, e.g. {{?RFC1918}}, link-local
-or unique local addresses. To support the discovery of Encrypted DNS in these environments, a means is needed for
-the discovery process to work from a locally-addressed Do53 resolver to an Encrypted DNS resolver that is accessible
+or unique local addresses. To support the discovery of encrypted DNS in these environments, a means is needed for
+the discovery process to work from a locally-addressed Do53 resolver to an encrypted DNS resolver that is accessible
 either at the same (local) address, or at a different global address. Both options need to be supported.
 
-# Network-identified encrypted resolvers
+## Use of designation information
+
+After the client receives designation information, it must come to a decision on whether and when to use any of the
+designated resolvers. To support this process, it would be advantageous for a solution to enable the client to validate
+the source of the assertion in some way. For example for both network-identified and resolver-identified designation, it
+may be possible to verify that the designation comes from an entity who already has full control of the client's Do53
+queries. It would be beneficial to extend this to defend against attackers that have only transient control of such queries.
+
+Clients may also seek to validate the identity of the designated resolver, beyond what is required by the relevant
+protocol. In general, clients may impose arbitrary additional requirements and heuristics as they see fit.
+
+
+## Network-identified designated resolvers
 
 DNS servers are often provisioned by a network as part of DHCP options {{?RFC2132}},
 IPv6 Router Advertisement (RA) options {{?RFC8106}}, Point-to-Point Protocol (PPP) {{?RFC1877}}, or
@@ -166,29 +183,61 @@ IPv6 Router Advertisement (RA) options {{?RFC8106}}, Point-to-Point Protocol (PP
 to be used for traditional unencrypted DNS.
 
 A solution is required that enhances the set of information delivered to include details of one or more
-equivalent encrypted DNS resolvers, or states that there are none.
+designated encrypted DNS resolvers, or states that there are none. Such resolvers could be on the local network, somewhere
+upstream, or on the public Internet.
 
-# Resolver-identified encrypted resolvers
+## Resolver-identified designated resolvers
 
 To support cases where the network is unable to identify an encrypted resolver, it should be possible to learn
-the details of one or more equivalent encrypted DNS resolvers by communicating with the network-recommended
+the details of one or more designated encrypted DNS resolvers by communicating with the network-recommended
 unencrypted Do53 resolver. This should involve an exchange that uses standard DNS messages that can be
 handled, or forwarded, by existing deployed software.
 
-It is frequently the case that Do53 resolvers announced by home networks are difficult to upgrade to support encrypted operation.
-In such cases it is possible that the only option for encrypted operation is to refer to a separate globally-addressed
-encrypted DNS resolver.
+Each resolver in the set may be at a different network location, which leads to several subcases for the mapping from Do53
+to a particular designated resolver.
+
+### Local to local
 
 If the local resolver has been upgraded to support encrypted DNS, the client may not initially be aware that its local resolver
 supports it. Discovering this may require communication with the local resolver, or an upstream resolver, over Do53.
 Clients that choose to use this local encrypted DNS gain the benefits of encryption while retaining the benefits
 of a local caching resolver with knowledge of the local topology.
 
+Clients will be aware when the designated resolver has the same IP address as the Do53 (after looking up its name if required). They
+can use this information in their decision-making as to the level of trust to place in the designated resolver.
+In some networks it will not be possible to deploy encrypted DNS on the same IP address, e.g. because of the increased
+resource requirements of encrypted DNS. Discovery solutions should work in the presence of a change of address.
+
 An additional benefit of using a local resolver occurs with IoT devices. A common usage pattern for such devices
 is for it to "call home" to a service that resides on the public Internet, where that service is referenced through a
 domain name. As discussed in Manufacturer Usage Description Specification {{?RFC8520}}, because these devices
 tend to require access to very few sites, all other access should be considered suspect. However, if the query
 is not accessible for inspection, it becomes quite difficult for the infrastructure to suspect anything.
+
+### Local to upstream
+
+It is frequently the case that Do53 resolvers announced by home networks are difficult to upgrade to support encrypted operation.
+In such cases it is possible that the only option for encrypted operation is to refer to a separate globally-addressed
+encrypted DNS resolver, somewhere upstream. Other networks may choose deploy their encrypted DNS resolver away from the
+local network, for other reasons.
+
+The use of an upstream resolver can mean the loss of local knowledge, such as the ability to respond to queries for
+locally-relevant names. Solutions should consider how to guide clients when to direct their queries to the local Do53.
+For example this could be through pre-emptive communication ("if you ever need to query *.example.com, use your local Do53"),
+or reactively ("I don't know the answer to that, but your local Do53 should know").
+
+### Public to public
+
+In cases where the local network has recommended a Do53 resolver on the public Internet, this resolver may designate its
+own or another public encrypted DNS service. Since public IP addresses may appear in TLS certificates, solutions may
+use this as one way to validate that the designated encrypted resolver is legitimately associated with the original Do53.
+
+## Identification over an encrypted channel
+
+In cases where the designation is delivered over an authenticated and encrypted channel, such as when one encrypted DNS
+resolver designates another, one form of attack is removed. Specifically, clients may be more confident that the received
+designation was actually sent by the designator. Clients may take this into account when deciding whether to follow the
+designation.
 
 
 # Privacy and security requirements {#priv-sec}
@@ -212,11 +261,7 @@ privacy posture. In particular, attackers under consideration must not be able t
 
 - Override or interfere with the resolver preferences of a user or administrator.
 
-- Cause clients to use a discovered resolver which has no authenticated delegation from a client-known entity.
-
-- Influence automatic discovery mechanisms such that a client uses one or more resolvers that are not
-otherwise involved with providing service to the client, such as: a network provider, a VPN server, a
-content provider being accessed, or a server that the client has manually configured.
+- Cause clients to use a discovered resolver which has no designation from a client-known entity.
 
 When discovering DNS resolvers on a local network, clients have no mechanism to distinguish between cases 
 where an active attacker with the above capabilities is interfering with discovery, and situations wherein 
@@ -232,23 +277,22 @@ this threat model may have limited value.
 This section lists requirements that flow from the above sections.
 
 | Requirement | Description |
-| R1.1 | Discovery MUST provide a local network the ability to announce to clients a set of, or absence of, equivalent resolvers. |
-| R1.2 | Discovery MUST provide a resolver the ability to announce to clients a set of, or absence of, equivalent resolvers. |
+| R1.1 | Discovery SHOULD provide a local network the ability to announce to clients a set of, or absence of, designated resolvers. |
+| R1.2 | Discovery SHOULD provide a resolver the ability to announce to clients a set of, or absence of, designated resolvers. |
 | R1.3 | Discovery MUST support at least one encrypted DNS protocol. |
 | R1.4 | Discovery SHOULD support all standardised encrypted DNS protocols. |
-| R2.1 | Networks MUST be able to announce one or more equivalent encrypted DNS resolvers using existing mechanisms such as DHCPv4, DHCPv6, IPv6 Router Advertisement, and the Point-to-Point Protocol. |
-| R2.2 | The format for resolver information MUST be specified such that provisioning mechanisms defined outside of the IETF can advertise encrypted DNS resolvers. |
+| R2.1 | Networks SHOULD be able to announce one or more designated encrypted DNS resolvers using existing mechanisms such as DHCPv4, DHCPv6, IPv6 Router Advertisement, and the Point-to-Point Protocol. |
+| R2.2 | The format for resolver designation SHOULD be specified such that provisioning mechanisms defined outside of the IETF can advertise encrypted DNS resolvers. |
+| R2.3 | This format SHOULD convey, at minimum, the information the client needs to make contact with each designated resolver. |
+| R2.4 | This format MAY convey more information. |
 | R3.1 | When discovery is instantiated from a resolver (R1.2), that resolver MAY be encrypted or not. |
-| R3.2 | When discovery is instantiated from a resolver (R1.2), that resolver MAY be locally or globally reachable. Both options MUST be supported. |
-| R4.1 | In a home network use case, if the local network forwarder does not offer encrypted DNS service, the ISP's encrypted DNS server information MUST be retrievable via a query sent to a local network forwarder. |
-| R4.2 | Encrypted DNS server discovery MUST NOT require any changes to DNS forwarders hosted on non-upgradable legacy network devices. |
+| R3.2 | When discovery is instantiated from a resolver (R1.2), that resolver MAY be locally or globally reachable. Both options SHOULD be supported. |
+| R4.1 | In a home network use case, if the local network resolver is a forwarder that does not offer encrypted DNS service, an upstream encrypted resolver SHOULD be retrievable via queries sent to that forwarder. |
+| R4.2 | Achieving requirement 4.1 SHOULD NOT require any changes to DNS forwarders hosted on non-upgradable legacy network devices. |
 | R5.1 | Discovery MUST NOT worsen a client's security or privacy posture. |
 | R5.2 | Threat modelling MUST assume that there is a passive eavesdropping attacker on the local network. |
 | R5.3 | Threat modelling MUST assume that an attacker can actively attack from outside the local network. |
 | R5.4 | Attackers MUST NOT be able to redirect encrypted DNS traffic to themselves when they would not otherwise handle DNS traffic. |
-| R5.5 | An attacker in the network MUST NOT be able to override or interfere with the resolver preferences of a user or administrator.   |
-| R5.6 | Attackers MUST NOT be able to influence automatic discovery mechanisms such that a client uses one or more resolvers that are not otherwise involved with providing service to the client, including a network provider, a VPN server, a content provider being accessed, or a server that the client has manually configured. |
-
 
 # Security Considerations
 
@@ -260,17 +304,14 @@ See {{priv-sec}}.
 This document has no IANA actions.
 
 
-
 --- back
 
 # Acknowledgments
 {:numbered="false"}
 
-This document was started based on discussion during the ADD meeting of IETF108, the subsequent interims,
+This document was started based on discussion during the ADD meeting of IETF108, subsequent meetings,
 on the list, and with text from draft-pauly-add-requirements. In particular this document was informed by contributions
 from Martin Thomson, Eric Rescorla, Tommy Jensen, Ben Schwartz, Paul Hoffman, Ralf Weber, Michael Richardson,
-Mohamed Boucadair, Sanjay Mishra, Jim Reid, Neil Cook, Nic Leymann and Andrew Campling.
-
-
-
+Mohamed Boucadair, Sanjay Mishra, Jim Reid, Neil Cook, Nic Leymann, Andrew Campling, Eric Orth, Ted Hardie,
+Paul Vixie, Vittorio Bertola, and Vinny Parla.
 

--- a/draft-add-requirements.md
+++ b/draft-add-requirements.md
@@ -284,8 +284,7 @@ This section lists requirements that flow from the above sections.
 | Requirement | Description |
 | R1.1 | Discovery SHOULD provide a local network the ability to announce to clients a set of, or absence of, designated resolvers. |
 | R1.2 | Discovery SHOULD provide a resolver the ability to announce to clients a set of, or absence of, designated resolvers. |
-| R1.3 | Discovery MUST support at least one encrypted DNS protocol. |
-| R1.4 | Discovery SHOULD support all standardised encrypted DNS protocols. |
+| R1.3 | Discovery SHOULD support all standardised encrypted DNS protocols. |
 | R2.1 | Networks SHOULD be able to announce one or more designated encrypted DNS resolvers using existing mechanisms such as DHCPv4, DHCPv6, IPv6 Router Advertisement, and the Point-to-Point Protocol. |
 | R2.2 | The format for resolver designation SHOULD be specified such that provisioning mechanisms defined outside of the IETF can advertise encrypted DNS resolvers. |
 | R2.3 | This format SHOULD convey, at minimum, the information the client needs to make contact with each designated resolver. |


### PR DESCRIPTION
This PR simplifies further by removing any mention of properties of the encrypted resolvers, or properties of the relationship between the Do53 and the encrypted resolver. It now purely focusses on the ability of an untrusted network or resolver to designate other encrypted resolvers. This is an assertion that the encrypted resolver is safe and appropriate to use, but little else. Clients will of course make their own decisions about whether to use designated resolvers or not. Other drafts will look at trusted networks, and communicating information that can be useful to clients as part of the untrusted decision-making.
